### PR TITLE
Fixed typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,9 @@ Example::
       Add variable i.e (operator: : drunken_master)      
 
     Should it have meta info?  [Y/n] 
-     - Should it have dependecies?  [Y/n] 
-        Add dependecy i.e ({role: aptsupercow, var: 'value'}) {role: cool, version: latest}
-        Add dependecy i.e ({role: aptsupercow, var: 'value'}) 
+     - Should it have dependencies?  [Y/n] 
+        Add dependency i.e ({role: aptsupercow, var: 'value'}) {role: cool, version: latest}
+        Add dependency i.e ({role: aptsupercow, var: 'value'}) 
 
     Should it have templates?  [Y/n] n
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -34,9 +34,9 @@ folders['defaults'] = {
 
 folders['meta']= {
     'question': '\nShould it have meta info? ',
-    'pre_hint': ' - Should it have dependecies? ',
+    'pre_hint': ' - Should it have dependencies? ',
     'pre_action': '\ndependencies:\n',
-    'hint': '    Add dependecy i.e ({role: aptsupercow, var: \'value\'}) ',
+    'hint': '    Add dependency i.e ({role: aptsupercow, var: \'value\'}) ',
     'action': '  - {}\n'
 }
 


### PR DESCRIPTION
'dependecy' -> 'dependency', 'dependecies' -> 'dependencies'
